### PR TITLE
core: add tap_dir helper; use it

### DIFF
--- a/lib/autoupdate.rb
+++ b/lib/autoupdate.rb
@@ -2,9 +2,11 @@
 
 require "date"
 require "fileutils"
+require "formula"
 require "pathname"
-require_relative "autoupdate/core"
+require "tap"
 require_relative "autoupdate/cleanup"
+require_relative "autoupdate/core"
 require_relative "autoupdate/delete"
 require_relative "autoupdate/notify"
 require_relative "autoupdate/start"

--- a/lib/autoupdate/core.rb
+++ b/lib/autoupdate/core.rb
@@ -27,5 +27,10 @@ module Autoupdate
     def location
       Pathname.new(File.expand_path("~/Library/Application Support/#{name}"))
     end
+
+    def tap_dir
+      origin = Tap.names.join(" ").match(%r{(domt4|homebrew)/autoupdate})[1]
+      Pathname.new(File.join(HOMEBREW_LIBRARY, "Taps", origin, "homebrew-autoupdate"))
+    end
   end
 end

--- a/lib/autoupdate/notify.rb
+++ b/lib/autoupdate/notify.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "formula"
-require "tap"
-
 module Autoupdate
   module Notify
     module_function

--- a/lib/autoupdate/notify.rb
+++ b/lib/autoupdate/notify.rb
@@ -44,9 +44,7 @@ module Autoupdate
     end
 
     def notifier_app
-      origin = Tap.names.join(" ").match(%r{(domt4|homebrew)/autoupdate})[1]
-      File.join(HOMEBREW_REPOSITORY, "Library", "Taps", origin,
-                "homebrew-autoupdate", "notifier", "brew-autoupdate.app")
+      File.join(Autoupdate::Core.tap_dir, "notifier", "brew-autoupdate.app")
     end
 
     def new_notify

--- a/lib/autoupdate/version.rb
+++ b/lib/autoupdate/version.rb
@@ -4,21 +4,19 @@ module Autoupdate
   module_function
 
   def generate_version_notes
-    # Reused code from notify; could be combined logic eventually.
-    origin = Tap.names.join(" ").match(%r{(domt4|homebrew)/autoupdate})[1]
-    tap = Pathname.new(File.join(HOMEBREW_REPOSITORY, "Library", "Taps", origin, "homebrew-autoupdate"))
-
+    tapdir = Autoupdate::Core.tap_dir
     log = nil
-    unless (tap/".git/shallow").exist?
-      last_version = Utils.popen_read("git", "-C", tap.to_s, "log", "--oneline",
+
+    unless (tapdir/".git/shallow").exist?
+      last_version = Utils.popen_read("git", "-C", tapdir, "log", "--oneline",
                                       "--grep=version: bump", "-n1", "--skip=1",
                                       "--pretty=format:'%h'").delete("'").chomp
 
-      current_version = Utils.popen_read("git", "-C", tap.to_s, "log", "--oneline",
+      current_version = Utils.popen_read("git", "-C", tapdir, "log", "--oneline",
                                          "--grep=version: bump", "-n1",
                                          "--pretty=format:'%h'").delete("'").chomp
 
-      log = Utils.popen_read("git", "-C", tap.to_s, "log", "--oneline", "--no-merges",
+      log = Utils.popen_read("git", "-C", tapdir, "log", "--oneline", "--no-merges",
                              "#{last_version}..#{current_version}").chomp
     end
 


### PR DESCRIPTION
* Adds a `tap_dir` helper to `core`, unifying the code in `notify` and `version`.
* Uses that new helper in the aforementioned files to streamline the code.
* Unifies some `requires`, and alphabetises the require-all `autoupdate.rb` file.