### PR TITLE
autoupdate: add `--immediate` flag for `start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ brew autoupdate status:
     Prints the current status of this tool.
 
 brew autoupdate version:
-    Output this tool's current version.
+    Output this tool's current version, and a short changelog.
 
       --upgrade                    Automatically upgrade your installed
                                    formulae. If the Caskroom exists locally
@@ -59,9 +59,14 @@ brew autoupdate version:
                                    process has finished successfully, if
                                    terminal-notifier is installed & found.
                                    Note that currently a new experimental
-                                   notifier runs automatically on macOS Big
-                                   Sur, without requiring any external
-                                   dependencies. Must be passed with start.
+                                   notifier runs automatically on macOS
+                                   Catalina and newer, without requiring any
+                                   external dependencies. Must be passed with
+                                   start.
+      --immediate                  Starts the autoupdate command immediately,
+                                   instead of waiting for one interval (24
+                                   hours by default) to pass first. Must be
+                                   passed with start.
   -d, --debug                      Display any debugging information.
   -q, --quiet                      Make some output more quiet.
   -v, --verbose                    Make some output more verbose.

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -45,6 +45,9 @@ module Homebrew
                           "if `terminal-notifier` is installed & found. Note that currently a new " \
                           "experimental notifier runs automatically on macOS Catalina and newer, without " \
                           "requiring any external dependencies. Must be passed with `start`."
+      switch "--immediate",
+             description: "Starts the autoupdate command immediately, instead of waiting for one interval " \
+                          "(24 hours by default) to pass first. Must be passed with `start`."
 
       named_args SUBCOMMANDS
     end

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -33,7 +33,7 @@ module Homebrew
         Prints the current status of this tool.
 
         `brew autoupdate version`:
-        Output this tool's current version.
+        Output this tool's current version, and a short changelog.
       EOS
       switch "--upgrade",
              description: "Automatically upgrade your installed formulae. If the Caskroom exists locally " \
@@ -43,8 +43,8 @@ module Homebrew
       switch "--enable-notification",
              description: "Send a notification when the autoupdate process has finished successfully, " \
                           "if `terminal-notifier` is installed & found. Note that currently a new " \
-                          "experimental notifier runs automatically on macOS Big Sur, without requiring " \
-                          "any external dependencies. Must be passed with `start`."
+                          "experimental notifier runs automatically on macOS Catalina and newer, without " \
+                          "requiring any external dependencies. Must be passed with `start`."
 
       named_args SUBCOMMANDS
     end

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -115,13 +115,11 @@ module Autoupdate
 
     interval ||= "86400"
 
-    # This restores the "Run At Load" key removed in a7de771abcf6 in debug-only
-    # scenarios. The debug flag currently has no other consequences, but that
-    # may change over time, so please don't rely on that flag's behaviour.
-    debug = if args.debug?
+    # This restores the "Run At Load" key removed in a7de771abcf6 when requested.
+    launch_immediately = if args.immediate?
       <<~EOS
         <key>RunAtLoad</key>
-        <true/>
+          <true/>
       EOS
     else
       ""
@@ -140,7 +138,7 @@ module Autoupdate
         <array>
             <string>#{Autoupdate::Core.location}/brew_autoupdate</string>
         </array>
-        #{debug}
+        #{launch_immediately.chomp}
         <key>StandardErrorPath</key>
         <string>#{log_out}</string>
         <key>StandardOutPath</key>


### PR DESCRIPTION
Starting immediately is useful for both debugging and for various use-cases beyond that, so let's support it formally rather than hiding it behind the `--debug` flag.