### PR TITLE
version: bump to 2.15.0

### DIFF
--- a/lib/autoupdate/version.rb
+++ b/lib/autoupdate/version.rb
@@ -31,7 +31,7 @@ module Autoupdate
 
   def version
     puts <<~EOS
-      Version 2.14.0. Last Changed: May 2021
+      Version 2.15.0. Last Changed: May 2021
 
     EOS
     generate_version_notes


### PR DESCRIPTION
Changes since last version:

1be3b4c version: bump to 2.15.0
cfeb480 README: update help text
0f5b9e2 start: add full support for running immediately
1e5fd25 autoupdate: add --immediate switch to `start`.
6042eb9 autoupdate: minor description changes
df59fef status: determine days old; warn user if not restarted periodically
8dd3ee2 notify: remove redundant requires
55dd445 notify: use core tap_dir helper
d70752c version: use core tap_dir helper
901cabc core: add tap_dir helper
26e4244 autoupdate: alphabetise; require tap/formula
7dcedb8 version: add autogenerated release notes