### PR TITLE
 Create a unique launch agent for each architecture

### DIFF
--- a/lib/autoupdate/cleanup.rb
+++ b/lib/autoupdate/cleanup.rb
@@ -4,11 +4,13 @@ module Autoupdate
   module_function
 
   def cleanup
-    fallback_logs = Dir[File.join(Autoupdate::Core.fallback_logs, "#{Autoupdate::Core.name}.*")]
+    log_files = Dir[File.join(Autoupdate::Core.fallback_logs, "**/#{Autoupdate::Core.base_name}.out")] |
+                Dir[File.join(Autoupdate::Core.fallback_logs, "**/#{Autoupdate::Core.name}.out")]
+    logs = Autoupdate::Core.logs
 
-    FileUtils.rm_f fallback_logs
+    FileUtils.rm_f log_files
     FileUtils.rm_f Autoupdate::Core.plist
     FileUtils.rm_rf Autoupdate::Core.location
-    FileUtils.rm_rf Autoupdate::Core.logs
+    FileUtils.rmdir logs if File.exist?(logs) && Dir["#{logs}/*"].empty?
   end
 end

--- a/lib/autoupdate/core.rb
+++ b/lib/autoupdate/core.rb
@@ -4,8 +4,14 @@ module Autoupdate
   module Core
     module_function
 
-    def name
+    def base_name
       "com.github.domt4.homebrew-autoupdate"
+    end
+
+    def name
+      return base_name if File.exist?(File.expand_path("~/Library/LaunchAgents/#{base_name}.plist"))
+
+      "#{base_name}.#{Hardware::CPU.arch}"
     end
 
     def plist
@@ -17,7 +23,7 @@ module Autoupdate
     end
 
     def logs
-      File.expand_path("~/Library/Logs/#{name}")
+      File.expand_path("~/Library/Logs/#{base_name}")
     end
 
     def fallback_logs


### PR DESCRIPTION
> Apologies for the double-up; #62 was based on my `master` branch and I was hoping the PR would follow when I renamed it while rebasing on the upstream `master`. Lesson learned: **always** branch before opening a PR! The original description follows.

On an Apple Silicon system with 2 Homebrew installations (at `/opt/homebrew` and `/usr/local` for arm64 and x86_64 respectively), `arch --x86_64 /usr/local/bin/brew autoupdate subcommand` conflicts with `/opt/homebrew/bin/brew autoupdate subcommand`, which makes it impossible to enable autoupdate for both installations simultaneously.

The workaround I've used here may not be suitable for wider adoption, but hopefully a few revisions will get it there if not.

TL;DR:

- the LaunchAgent's name now includes the applicable architecture (e.g. `com.github.domt4.homebrew-autoupdate.arm64`)
- the previous name is kept if `~/Library/LaunchAgents/com.github.domt4.homebrew-autoupdate.plist` already exists (the new name only takes effect after `brew autoupdate delete`)
- `~/Library/Logs/com.github.domt4.homebrew-autoupdate/` isn't deleted unless it's empty

There are probably things I've missed, but it seems to be working as expected here (although I don't have `--upgrade` enabled).