### PR TITLE
feat(start): respect `HOMEBREW_CASK_OPTS` env

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -58,6 +58,7 @@ module Autoupdate
     env_logs = ENV.fetch("HOMEBREW_LOGS") if ENV["HOMEBREW_LOGS"]
     env_dev = ENV.fetch("HOMEBREW_DEVELOPER") if ENV["HOMEBREW_DEVELOPER"]
     env_stats = ENV.fetch("HOMEBREW_NO_ANALYTICS") if ENV["HOMEBREW_NO_ANALYTICS"]
+    env_cask = ENV.fetch("HOMEBREW_CASK_OPTS") if ENV["HOMEBREW_CASK_OPTS"]
     env_sudo = ENV.fetch("SUDO_ASKPASS") if ENV["SUDO_ASKPASS"]
     env_path = ENV.fetch("PATH")
 
@@ -71,6 +72,7 @@ module Autoupdate
     set_env << "\nexport HOMEBREW_LOGS='#{env_logs}'" if env_logs
     set_env << "\nexport HOMEBREW_DEVELOPER=#{env_dev}" if env_dev
     set_env << "\nexport HOMEBREW_NO_ANALYTICS=#{env_stats}" if env_stats
+    set_env << "\nexport HOMEBREW_CASK_OPTS=#{env_cask}" if env_cask
     set_env << "\nexport SUDO_ASKPASS=#{env_sudo}" if env_sudo
 
     script_contents = <<~EOS


### PR DESCRIPTION
## 😷 Fix the macOS Quarantine
<img src="https://user-images.githubusercontent.com/834636/127720078-0031ce24-cf94-4cc4-b641-b8e4da4be958.png" align="right" width="40%">

My half-assed attempt at trying to fix the annoying macOS quarantine "[The app can’t be opened because it is from an unidentified developer](https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/faq/app_cant_be_opened.md)" error.

### How

Respecting the `HOMEBREW_CASK_OPTS` env var, just like some other env vars are already respected.

As discussed in https://github.com/Homebrew/homebrew-autoupdate/issues/66#issuecomment-890227342. Based on the information from https://github.com/Homebrew/homebrew-cask/blob/HEAD/USAGE.md#options.

#### Usage Example

```sh
# Automatically upgrade every 12 hours, including the `--no-quarantine` flag to
# avoid annoying macOS quarantine warnings.
HOMEBREW_CASK_OPTS="--no-quarantine" brew autoupdate start 43200 --upgrade
```

### TODO

- [ ] Tests
- [ ] Documentation

### Alternatives

Even when going with an alternative approach, I think respecting `HOMEBREW_CASK_OPTS` is worthwile either way.

- Statically or conditionally pass `--no-quarantine` as part of:
  - https://github.com/Homebrew/homebrew-autoupdate/blob/51b00cffa1e8a0d4ca7e143c1436cbd98f090531/lib/autoupdate/start.rb#L19
  - https://github.com/Homebrew/homebrew-autoupdate/blob/51b00cffa1e8a0d4ca7e143c1436cbd98f090531/lib/autoupdate/start.rb#L38