### PR TITLE
Clarify ambiguity on notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,9 @@ brew autoupdate version:
       --enable-notification        Send a notification when the autoupdate
                                    process has finished successfully, if
                                    terminal-notifier is installed & found.
-                                   Note that currently a new experimental
-                                   notifier runs automatically on macOS
-                                   Catalina and newer, without requiring any
-                                   external dependencies. Must be passed with
-                                   start.
+                                   Must be passed with start.
+                                   NOTE: Notifications are enabled by default
+                                   on macOS Catalina and newer.
       --immediate                  Starts the autoupdate command immediately,
                                    instead of waiting for one interval (24
                                    hours by default) to pass first. Must be

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -42,9 +42,8 @@ module Homebrew
              description: "Automatically clean brew's cache and logs. Must be passed with `start`."
       switch "--enable-notification",
              description: "Send a notification when the autoupdate process has finished successfully, " \
-                          "if `terminal-notifier` is installed & found. Note that currently a new " \
-                          "experimental notifier runs automatically on macOS Catalina and newer, without " \
-                          "requiring any external dependencies. Must be passed with `start`."
+                          "if `terminal-notifier` is installed & found. Must be passed with `start`. " \
+                          "<NOTE: Notifications are enabled by default on macOS Catalina and newer.>"
       switch "--immediate",
              description: "Starts the autoupdate command immediately, instead of waiting for one interval " \
                           "(24 hours by default) to pass first. Must be passed with `start`."


### PR DESCRIPTION
"Experimental notifier runs automatically" doesn't necessarily imply that _notifications_ are enabled automatically.

Addreses https://github.com/Homebrew/discussions/discussions/2915#discussioncomment-2120548.