### PR TITLE
Add --greedy argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ brew autoupdate version:
                                    formulae. If the Caskroom exists locally
                                    Casks will be upgraded as well. Must be
                                    passed with start.
+      --greedy                     Upgrade casks with --greedy. See brew(1).
+                                   Must be passed with start.
       --cleanup                    Automatically clean brew's cache and logs.
                                    Must be passed with start.
       --enable-notification        Send a notification when the autoupdate

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -38,6 +38,9 @@ module Homebrew
       switch "--upgrade",
              description: "Automatically upgrade your installed formulae. If the Caskroom exists locally " \
                           "Casks will be upgraded as well. Must be passed with `start`."
+      switch '--greedy',
+             description: 'Upgrade casks with --greedy. See brew(1).' \
+                          'Must be passed with `start`.'
       switch "--cleanup",
              description: "Automatically clean brew's cache and logs. Must be passed with `start`."
       switch "--enable-notification",

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -38,9 +38,9 @@ module Homebrew
       switch "--upgrade",
              description: "Automatically upgrade your installed formulae. If the Caskroom exists locally " \
                           "Casks will be upgraded as well. Must be passed with `start`."
-      switch '--greedy',
-             description: 'Upgrade casks with --greedy. See brew(1).' \
-                          'Must be passed with `start`.'
+      switch "--greedy",
+             description: "Upgrade casks with --greedy. See brew(1)." \
+                          "Must be passed with `start`."
       switch "--cleanup",
              description: "Automatically clean brew's cache and logs. Must be passed with `start`."
       switch "--enable-notification",

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -35,7 +35,8 @@ module Autoupdate
           EOS
         end
 
-        auto_args << " && #{Autoupdate::Core.brew} upgrade --cask --greedy -v"
+        greedy = args.greedy? ? " --greedy" : ""
+        auto_args << " && #{Autoupdate::Core.brew} upgrade --cask -v#{greedy}"
       end
 
       auto_args << " && #{Autoupdate::Core.brew} cleanup" if args.cleanup?


### PR DESCRIPTION
`--greedy` cask upgrade is now opt-in instead of mandatory.

Fixes #58

## Testing
I'm not sure how to properly test this. This is what I did

1. Switch to my branch in the system's brew tap
  ```console
  $ cd "$(brew --repository homebrew/homebrew-autoupdate)"
  $ git remote add erikw git@github.com:erikw/homebrew-autoupdate.git
  $ git fetch erikw
  $ git checkout opt-in-greedy
  ```
1. In `lib/autoupdate/start.rb` I added a little argument logger [here](https://github.com/Homebrew/homebrew-autoupdate/blob/dfb2bdc5798ece8f842847369054e9833c7aef93/lib/autoupdate/start.rb#L77) of what will be executed:
  ```ruby
      File.open("/tmp/start.rb.log", "a") do |f|
        f.write auto_args
      end
  ```
1. Enable the autoupdate with and without the `--greedy`
  ```console
  $ brew autoupdate start 5 --upgrade
  $ brew autoupdate stop
  $ brew autoupdate start 5 --upgrade --greedy
  ```
1. View the captured `auto_args` in `/tmp/start.rb.log`:
<pre>
 update && /usr/local/bin/brew upgrade --formula -v && /usr/local/bin/brew upgrade --cask -v && /usr/bin/open -g /usr/local/Homebrew/Library/Taps/homebrew/homebrew-autoupdate/notifier/brew-autoupdate.app
 update && /usr/local/bin/brew upgrade --formula -v && /usr/local/bin/brew upgrade --cask -v <b>--greedy</b> && /usr/bin/open -g /usr/local/Homebrew/Library/Taps/homebrew/homebrew-autoupdate/notifier/brew-autoupdate.app
</pre>

So... it seems to work...


--- 
Before we can merge this, it would be good to:
* Get feedback from someone that is more familiar with the code base like @DomT4, as I might have missed some place to edit.
* Tested by someone more than me