### PR TITLE
start: start phasing out `--enable-notification` on 10.15+

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -55,6 +55,13 @@ module Autoupdate
     # applet proves itself consistently reliable & can be considered mostly complete.
     if args.enable_notification? && MacOS.version < :yosemite
       odie "terminal-notifier has deprecated support for anything below Yosemite"
+    elsif args.enable_notification? && MacOS.version >= :catalina
+      opoo <<~EOS
+        Notifications are automatically enabled for macOS Catalina
+        and newer using a native Applet. Passing --enable-notification
+        is no longer required.
+
+      EOS
     elsif args.enable_notification? && Autoupdate::Notify.notifier
       opoo <<~EOS
         Notification support for macOS versions older than


### PR DESCRIPTION
`--enable-notification` hasn't been required on newer versions of macOS for some time as it is automatic. At some point I'd like the flag to go away/stop taking up unnecessary codespace after the old style notifications are removed entirely (~October 2022) so this is a step towards that.