### PR TITLE
autoupdate: Fix `greedy` docs

### DIFF
--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -39,7 +39,7 @@ module Homebrew
              description: "Automatically upgrade your installed formulae. If the Caskroom exists locally " \
                           "Casks will be upgraded as well. Must be passed with `start`."
       switch "--greedy",
-             description: "Upgrade casks with --greedy. See brew(1)." \
+             description: "Upgrade casks with --greedy (include auto-updating casks). " \
                           "Must be passed with `start`."
       switch "--cleanup",
              description: "Automatically clean brew's cache and logs. Must be passed with `start`."


### PR DESCRIPTION
- I noticed a missing space in https://github.com/Homebrew/brew/pull/12962. Plus I was confused there as to why we tell people to look at `brew(1)` when these docs appear there too. Instead, let's give a brief in-line description of what `--greedy` does for casks.