### PR TITLE
Updated description of --immediate to include that it will also run after every reboot instead of waiting for 1 interval to pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ brew autoupdate version:
                                    NOTE: Notifications are enabled by default
                                    on macOS Catalina and newer.
       --immediate                  Starts the autoupdate command immediately
-                                   and after every reboot,
+                                   and on system boot,
                                    instead of waiting for one interval (24
                                    hours by default) to pass first. Must be
                                    passed with start.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ brew autoupdate version:
                                    Must be passed with start.
                                    NOTE: Notifications are enabled by default
                                    on macOS Catalina and newer.
-      --immediate                  Starts the autoupdate command immediately,
+      --immediate                  Starts the autoupdate command immediately
+                                   and after every reboot,
                                    instead of waiting for one interval (24
                                    hours by default) to pass first. Must be
                                    passed with start.

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -22,7 +22,7 @@ module Homebrew
         `brew autoupdate start 43200`. If you want to start the autoupdate immediately
         and after every reboot, pass `--immediate`. Pass `--upgrade` or `--cleanup`
         to automatically run `brew upgrade` and/or `brew cleanup` respectively.
-        Pass `--enable-notification` to send a notification when the autoupdate 
+        Pass `--enable-notification` to send a notification when the autoupdate
         process has finished successfully.
 
         `brew autoupdate stop`:

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -19,9 +19,11 @@ module Homebrew
         `brew autoupdate start` [<`interval`>] [<`options`>]:
         Start autoupdating either once every `interval` hours or once every 24 hours.
         Please note the interval has to be passed in seconds, so 12 hours would be
-        `brew autoupdate start 43200`. Pass `--upgrade` or `--cleanup` to automatically
-        run `brew upgrade` and/or `brew cleanup` respectively. Pass `--enable-notification`
-        to send a notification when the autoupdate process has finished successfully.
+        `brew autoupdate start 43200`. If you want to start the autoupdate immediately
+        and after every reboot, pass `--immediate`. Pass `--upgrade` or `--cleanup`
+        to automatically run `brew upgrade` and/or `brew cleanup` respectively.
+        Pass `--enable-notification` to send a notification when the autoupdate 
+        process has finished successfully.
 
         `brew autoupdate stop`:
         Stop autoupdating, but retain plist and logs.
@@ -48,8 +50,9 @@ module Homebrew
                           "if `terminal-notifier` is installed and found. Must be passed with `start`. " \
                           "Note: notifications are enabled by default on macOS Catalina and newer."
       switch "--immediate",
-             description: "Starts the autoupdate command immediately, instead of waiting for one interval " \
-                          "(24 hours by default) to pass first. Must be passed with `start`."
+             description: "Starts the autoupdate command immediately and after every reboot, " \
+                          "instead of waiting for one interval (24 hours by default) to pass first. " \
+                          "Must be passed with `start`."
 
       named_args SUBCOMMANDS
     end

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -20,7 +20,7 @@ module Homebrew
         Start autoupdating either once every `interval` hours or once every 24 hours.
         Please note the interval has to be passed in seconds, so 12 hours would be
         `brew autoupdate start 43200`. If you want to start the autoupdate immediately
-        and after every reboot, pass `--immediate`. Pass `--upgrade` or `--cleanup`
+        and on system boot, pass `--immediate`. Pass `--upgrade` or `--cleanup`
         to automatically run `brew upgrade` and/or `brew cleanup` respectively.
         Pass `--enable-notification` to send a notification when the autoupdate
         process has finished successfully.
@@ -50,7 +50,7 @@ module Homebrew
                           "if `terminal-notifier` is installed and found. Must be passed with `start`. " \
                           "Note: notifications are enabled by default on macOS Catalina and newer."
       switch "--immediate",
-             description: "Starts the autoupdate command immediately and after every reboot, " \
+             description: "Starts the autoupdate command immediately and on system boot, " \
                           "instead of waiting for one interval (24 hours by default) to pass first. " \
                           "Must be passed with `start`."
 

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -198,7 +198,7 @@ module Autoupdate
     if args.immediate?
       puts "#{update_message}, now, and on system boot."
     else
-      puts update_message + "."
+      puts "#{update_message}."
     end
   end
 end

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -194,6 +194,11 @@ module Autoupdate
     # It'll behave strangely if someone wants autoupdate
     # to run more than once an hour, but... surely not?
     interval_to_hours = interval.to_i / 60 / 60
-    puts "Homebrew will now automatically update every #{interval_to_hours} hours, or on system boot."
+    update_message = "Homebrew will now automatically update every #{interval_to_hours} hours"
+    if args.immediate?
+      puts "#{update_message}, now, and on system boot."
+    else
+      puts update_message + "."
+    end
   end
 end


### PR DESCRIPTION
If you want to start the autoupdate immediately and after every reboot, pass `--immediate`.