### PR TITLE
password gui with pinentry-mac for handling Casks that require sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ brew autoupdate version:
                                    instead of waiting for one interval (24
                                    hours by default) to pass first. Must be
                                    passed with start.
+      --sudo                       Run with `SUDO_ASKPASS` (which is required for some formulae).
   -d, --debug                      Display any debugging information.
   -q, --quiet                      Make some output more quiet.
   -v, --verbose                    Make some output more verbose.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ brew autoupdate version:
                                    instead of waiting for one interval (24
                                    hours by default) to pass first. Must be
                                    passed with start.
-      --sudo                       If a Cask requires sudo, autoupdate will open a GUI to ask for the password.
+      --sudo                       If a Cask requires sudo, autoupdate will 
+                                   open a GUI to ask for the password.
+                                   Requires https://formulae.brew.sh/formula/pinentry-mac
+                                   to be installed.
   -d, --debug                      Display any debugging information.
   -q, --quiet                      Make some output more quiet.
   -v, --verbose                    Make some output more verbose.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ brew autoupdate version:
                                    instead of waiting for one interval (24
                                    hours by default) to pass first. Must be
                                    passed with start.
-      --sudo                       Run with `SUDO_ASKPASS` (which is required for some formulae).
+      --sudo                       If a Cask requires sudo, autoupdate will open a GUI to ask for the password.
   -d, --debug                      Display any debugging information.
   -q, --quiet                      Make some output more quiet.
   -v, --verbose                    Make some output more verbose.
@@ -108,11 +108,6 @@ support added in [6365cc020](https://github.com/Homebrew/homebrew-autoupdate/com
 that doesn't require or use any external dependencies, using only an Applescript
 applet.
 [Related Issue](https://github.com/Homebrew/homebrew-autoupdate/issues/25)
-
-* Decide what to do about Cask upgrades which require `sudo` to succeed
-and currently just hang when that situation is encountered,
-unless using `SUDO_ASKPASS`.
-[Related Issue](https://github.com/Homebrew/homebrew-autoupdate/issues/40)
 
 ## History
 

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -22,6 +22,7 @@ module Homebrew
         `brew autoupdate start 43200`. Pass `--upgrade` or `--cleanup` to automatically
         run `brew upgrade` and/or `brew cleanup` respectively. Pass `--enable-notification`
         to send a notification when the autoupdate process has finished successfully.
+        Add `--sudo` to run `brew upgrade` with `SUDO_ASKPASS` (which is required for some formulae).
 
         `brew autoupdate stop`:
         Stop autoupdating, but retain plist and logs.
@@ -50,6 +51,8 @@ module Homebrew
       switch "--immediate",
              description: "Starts the autoupdate command immediately, instead of waiting for one interval " \
                           "(24 hours by default) to pass first. Must be passed with `start`."
+      switch "--sudo",
+             description: "Run `brew upgrade` with `SUDO_ASKPASS` (which is required for some formulae). " \
 
       named_args SUBCOMMANDS
     end

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -52,6 +52,7 @@ module Homebrew
                           "(24 hours by default) to pass first. Must be passed with `start`."
       switch "--sudo",
              description: "If a Cask requires sudo, autoupdate will open a GUI to ask for the password." \
+                          "Requires https://formulae.brew.sh/formula/pinentry-mac to be installed."
 
       named_args SUBCOMMANDS
     end

--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -22,7 +22,6 @@ module Homebrew
         `brew autoupdate start 43200`. Pass `--upgrade` or `--cleanup` to automatically
         run `brew upgrade` and/or `brew cleanup` respectively. Pass `--enable-notification`
         to send a notification when the autoupdate process has finished successfully.
-        Add `--sudo` to run `brew upgrade` with `SUDO_ASKPASS` (which is required for some formulae).
 
         `brew autoupdate stop`:
         Stop autoupdating, but retain plist and logs.
@@ -52,7 +51,7 @@ module Homebrew
              description: "Starts the autoupdate command immediately, instead of waiting for one interval " \
                           "(24 hours by default) to pass first. Must be passed with `start`."
       switch "--sudo",
-             description: "Run `brew upgrade` with `SUDO_ASKPASS` (which is required for some formulae). " \
+             description: "If a Cask requires sudo, autoupdate will open a GUI to ask for the password." \
 
       named_args SUBCOMMANDS
     end

--- a/gui/getpass.sh
+++ b/gui/getpass.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-PW="$(printf "%s\n" "SETOK OK" "SETCANCEL Cancel" "SETDESC homebrew-autoupdate needs your admin password to complete the task" "SETPROMPT Enter Password:$
-echo "$PW"

--- a/gui/getpass.sh
+++ b/gui/getpass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+PW="$(printf "%s\n" "SETOK OK" "SETCANCEL Cancel" "SETDESC homebrew-autoupdate needs your admin password to complete the task" "SETPROMPT Enter Password:$
+echo "$PW"

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -95,7 +95,7 @@ module Autoupdate
     set_env << "\nexport HOMEBREW_CASK_OPTS=#{env_cask}" if env_cask
 
     if args.sudo?
-      set_env << "\nexport SUDO_ASKPASS=#{Autoupdate::Core.location/"brew_autoupdate_sudo_gui"}"
+      set_env << "\nexport SUDO_ASKPASS='#{Autoupdate::Core.location/"brew_autoupdate_sudo_gui"}'"
       sudo_gui_script_contents = <<~EOS
       #!/bin/sh
       export PATH='#{env_path}'

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -97,11 +97,11 @@ module Autoupdate
     if args.sudo?
       set_env << "\nexport SUDO_ASKPASS='#{Autoupdate::Core.location/"brew_autoupdate_sudo_gui"}'"
       sudo_gui_script_contents = <<~EOS
-      #!/bin/sh
-      export PATH='#{env_path}'
-      PW="$(printf "%s\n" "SETOK OK" "SETCANCEL Cancel" "SETDESC homebrew-autoupdate needs your admin password to complete the upgrade" "SETPROMPT Enter Password:" "SETTITLE homebrew-autoupdate Password Request" "GETPIN" | pinentry-mac --no-global-grab | awk '/^D / {print substr($0, index($0, $2))}')"
-      echo "$PW"
-    EOS
+        #!/bin/sh
+        export PATH='#{env_path}'
+        PW="$(printf "%s\n" "SETOK OK" "SETCANCEL Cancel" "SETDESC homebrew-autoupdate needs your admin password to complete the upgrade" "SETPROMPT Enter Password:" "SETTITLE homebrew-autoupdate Password Request" "GETPIN" | pinentry-mac --no-global-grab | awk '/^D / {print substr($0, index($0, $2))}')"
+        echo "$PW"
+      EOS
     else
       set_env << "\nexport SUDO_ASKPASS=#{env_sudo}" if env_sudo
     end

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -102,8 +102,8 @@ module Autoupdate
         PW="$(printf "%s\n" "SETOK OK" "SETCANCEL Cancel" "SETDESC homebrew-autoupdate needs your admin password to complete the upgrade" "SETPROMPT Enter Password:" "SETTITLE homebrew-autoupdate Password Request" "GETPIN" | pinentry-mac --no-global-grab | awk '/^D / {print substr($0, index($0, $2))}')"
         echo "$PW"
       EOS
-    else
-      set_env << "\nexport SUDO_ASKPASS=#{env_sudo}" if env_sudo
+    elsif env_sudo
+      set_env << "\nexport SUDO_ASKPASS=#{env_sudo}"
     end
 
     script_contents = <<~EOS

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -24,13 +24,11 @@ module Autoupdate
         # comfortable enough with it I can tolerate it. Please consider the
         # risks of leaving your admin password laying around the system in
         # plaintext before using this, if you have no other use case for SUDO_ASKPASS.
-        if ENV["SUDO_ASKPASS"].nil?
+        if ENV["SUDO_ASKPASS"].nil? && !args.sudo?
           opoo <<~EOS
-            Please note if you use Casks that require `sudo` to upgrade there
-            are known issues with that use case and this command unless using
-            `SUDO_ASKPASS`.
-
-              https://github.com/Homebrew/homebrew-autoupdate/issues/40
+            Please note if you use Casks that require `sudo` to upgrade,
+            you need to use `--sudo` or defining a custom `SUDO_ASKPASS`
+            environment variable.
 
           EOS
         end

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -27,7 +27,7 @@ module Autoupdate
         if ENV["SUDO_ASKPASS"].nil? && !args.sudo?
           opoo <<~EOS
             Please note if you use Casks that require `sudo` to upgrade,
-            you need to use `--sudo` or defining a custom `SUDO_ASKPASS`
+            you need to use `--sudo` or define a custom `SUDO_ASKPASS`
             environment variable.
 
           EOS

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -95,6 +95,12 @@ module Autoupdate
     set_env << "\nexport HOMEBREW_CASK_OPTS=#{env_cask}" if env_cask
 
     if args.sudo?
+      unless Formula["pinentry-mac"].any_version_installed?
+        odie <<~EOS
+          `--sudo` requires https://formulae.brew.sh/formula/pinentry-mac to be installed.
+          Please run `brew install pinentry-mac` and try again.
+        EOS
+      end
       set_env << "\nexport SUDO_ASKPASS='#{Autoupdate::Core.location/"brew_autoupdate_sudo_gui"}'"
       sudo_gui_script_contents = <<~EOS
         #!/bin/sh

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -95,7 +95,7 @@ module Autoupdate
     set_env << "\nexport HOMEBREW_CASK_OPTS=#{env_cask}" if env_cask
 
     if args.sudo?
-      set_env << "\nextport SUDO_ASKPASS=#{Autoupdate::Core.location/"brew_autoupdate_sudo_gui"}"
+      set_env << "\nexport SUDO_ASKPASS=#{Autoupdate::Core.location/"brew_autoupdate_sudo_gui"}"
       sudo_gui_script_contents = <<~EOS
       #!/bin/sh
       export PATH='#{env_path}'

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -93,7 +93,12 @@ module Autoupdate
     set_env << "\nexport HOMEBREW_DEVELOPER=#{env_dev}" if env_dev
     set_env << "\nexport HOMEBREW_NO_ANALYTICS=#{env_stats}" if env_stats
     set_env << "\nexport HOMEBREW_CASK_OPTS=#{env_cask}" if env_cask
-    set_env << "\nexport SUDO_ASKPASS=#{env_sudo}" if env_sudo
+
+    #TODO: Fix if/else statement and fix path to script
+    if args.sudo?
+      set_env << "\nextport SUDO_ASKPASS=#{Autoupdate::Core}" if env_sudo
+    else
+      set_env << "\nexport SUDO_ASKPASS=#{env_sudo}" if env_sudo
 
     script_contents = <<~EOS
       #!/bin/sh


### PR DESCRIPTION
Solves Issue https://github.com/Homebrew/homebrew-autoupdate/issues/40

You can now pass the argument `--sudo` to the `start` command.
If a Cask requires sudo, pinetry-mac will open a gui to ask for the password:
![image](https://github.com/Homebrew/homebrew-autoupdate/assets/24353767/e96e59c0-e7f9-4d78-9e96-b0c91747ab48)
