### PR TITLE
Only create brew_autoupdate_sudo_gui script if --sudo is passed

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -19,11 +19,6 @@ module Autoupdate
       auto_args << " && #{Autoupdate::Core.brew} upgrade --formula -v"
 
       if (HOMEBREW_PREFIX/"Caskroom").exist?
-        # Support unattended Cask upgrades that require `sudo` where possible.
-        # Homebrew themselves permit this same workaround so if they're
-        # comfortable enough with it I can tolerate it. Please consider the
-        # risks of leaving your admin password laying around the system in
-        # plaintext before using this, if you have no other use case for SUDO_ASKPASS.
         if ENV["SUDO_ASKPASS"].nil? && !args.sudo?
           opoo <<~EOS
             Please note if you use Casks that require `sudo` to upgrade,

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -150,11 +150,9 @@ module Autoupdate
       FileUtils.chmod 0555, Autoupdate::Core.location/"brew_autoupdate"
     end
 
-    if args.sudo?
-      unless File.exist?(Autoupdate::Core.location/"brew_autoupdate_sudo_gui")
-        File.open(Autoupdate::Core.location/"brew_autoupdate_sudo_gui", "w") { |sc| sc << sudo_gui_script_contents }
-        FileUtils.chmod 0555, Autoupdate::Core.location/"brew_autoupdate_sudo_gui"
-      end
+    if args.sudo? && !File.exist?(Autoupdate::Core.location/"brew_autoupdate_sudo_gui")
+      File.open(Autoupdate::Core.location/"brew_autoupdate_sudo_gui", "w") { |sc| sc << sudo_gui_script_contents }
+      FileUtils.chmod 0555, Autoupdate::Core.location/"brew_autoupdate_sudo_gui"
     end
 
     interval ||= "86400"

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -150,9 +150,11 @@ module Autoupdate
       FileUtils.chmod 0555, Autoupdate::Core.location/"brew_autoupdate"
     end
 
-    unless File.exist?(Autoupdate::Core.location/"brew_autoupdate_sudo_gui")
-      File.open(Autoupdate::Core.location/"brew_autoupdate_sudo_gui", "w") { |sc| sc << sudo_gui_script_contents }
-      FileUtils.chmod 0555, Autoupdate::Core.location/"brew_autoupdate_sudo_gui"
+    if args.sudo?
+      unless File.exist?(Autoupdate::Core.location/"brew_autoupdate_sudo_gui")
+        File.open(Autoupdate::Core.location/"brew_autoupdate_sudo_gui", "w") { |sc| sc << sudo_gui_script_contents }
+        FileUtils.chmod 0555, Autoupdate::Core.location/"brew_autoupdate_sudo_gui"
+      end
     end
 
     interval ||= "86400"


### PR DESCRIPTION
I noticed that even when you do not pass `--sudo` to the `start` command, the file `brew_autoupdate_sudo_gui` was still created.
It was empty but still unnecessary.