### PR TITLE
Updated README.md file (removed embedded --help command output + fixed small spelling mistakes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 An easy, convenient way to automatically update Homebrew.
 
 This script will run `brew update` in the background once every 24 hours (by
-default) until explicitly told to stop, utilising `launchd`.
+default) until explicitly told to stop, utilizing `launchd`.
 
-`brew upgrade` and `brew cleanup` can also be handled automatically but
+`brew upgrade` and `brew cleanup` can also be handled automatically, but
 are optional flags.
 
 Notifications are enabled by default on macOS Big Sur using a new,
-codesigned, universal AppleScript applet. On older versions of macOS, if you
+code signed, universal AppleScript applet. On older versions of macOS, if you
 have `terminal-notifier` installed you can also request desktop notifications
 when this command runs.
 
@@ -19,64 +19,23 @@ when this command runs.
 
 Just `brew tap homebrew/autoupdate`.
 
+Now run `brew autoupdate start [interval] [options]` to enable autoupdate.
+
+## Example
+
+`brew  autoupdate start 43200 --upgrade --cleanup --immediate --sudo`
+
+This will upgrade all your casks and formulae every 12h and on every system boot. <br>
+If a sudo password is required for an upgrade, a GUI to enter you password will be displayed. <br>
+Also, it will clean up every old version and left-over files.
+
+Casks which have built-in auto updates enabled by default, will not be upgraded.
+
 ## Usage
 
-```
-Usage: brew autoupdate subcommand [interval] [options]
+Refer to the link below to find an in-depth description of the commands.
 
-An easy, convenient way to automatically update Homebrew.
-
-This script will run brew update in the background once every 24 hours (by
-default) until explicitly told to stop, utilising launchd.
-
-brew autoupdate start [interval] [options]:
-    Start autoupdating either once every interval hours or once every 24
-hours. Please note the interval has to be passed in seconds, so 12 hours would
-be brew autoupdate start 43200. Pass --upgrade or --cleanup to
-automatically run brew upgrade and/or brew cleanup respectively. Pass
---enable-notification to send a notification when the autoupdate process has
-finished successfully.
-
-brew autoupdate stop:
-    Stop autoupdating, but retain plist & logs.
-
-brew autoupdate delete:
-    Cancel the autoupdate, delete the plist and logs.
-
-brew autoupdate status:
-    Prints the current status of this tool.
-
-brew autoupdate version:
-    Output this tool's current version, and a short changelog.
-
-      --upgrade                    Automatically upgrade your installed
-                                   formulae. If the Caskroom exists locally
-                                   Casks will be upgraded as well. Must be
-                                   passed with start.
-      --greedy                     Upgrade casks with --greedy. See brew(1).
-                                   Must be passed with start.
-      --cleanup                    Automatically clean brew's cache and logs.
-                                   Must be passed with start.
-      --enable-notification        Send a notification when the autoupdate
-                                   process has finished successfully, if
-                                   terminal-notifier is installed & found.
-                                   Must be passed with start.
-                                   NOTE: Notifications are enabled by default
-                                   on macOS Catalina and newer.
-      --immediate                  Starts the autoupdate command immediately
-                                   and on system boot,
-                                   instead of waiting for one interval (24
-                                   hours by default) to pass first. Must be
-                                   passed with start.
-      --sudo                       If a Cask requires sudo, autoupdate will 
-                                   open a GUI to ask for the password.
-                                   Requires https://formulae.brew.sh/formula/pinentry-mac
-                                   to be installed.
-  -d, --debug                      Display any debugging information.
-  -q, --quiet                      Make some output more quiet.
-  -v, --verbose                    Make some output more verbose.
-  -h, --help                       Show this message.
-```
+**[Homebrew Documentation autoupdate subcommand](https://docs.brew.sh/Manpage#autoupdate-subcommand-interval-options)**
 
 **Logs of the performed operations can be found at:** `~/Library/Logs/com.github.domt4.homebrew-autoupdate`
 
@@ -89,7 +48,7 @@ any of `brew install`, `brew tap` or `brew upgrade`.
 
 If you run `brew` commands regularly yourself, you may wish to consider using
 the built-in autoupdate mechanism, which can be instructed to autoupdate less
-often or disabled entirely. If you wish to update every 24 hours using the
+often, or disabled entirely. If you wish to update every 24 hours using the
 built-in autoupdate mechanism set this in your environment:
 
 ```bash
@@ -108,7 +67,7 @@ autoupdate mechanism.
 ## TO-DO (PRs Welcome)
 
 * Complete broader testing and roll-out of new, experimental notification
-support added in [6365cc020](https://github.com/Homebrew/homebrew-autoupdate/commit/6365cc020)
+Support was added in [6365cc020](https://github.com/Homebrew/homebrew-autoupdate/commit/6365cc020)
 that doesn't require or use any external dependencies, using only an Applescript
 applet.
 [Related Issue](https://github.com/Homebrew/homebrew-autoupdate/issues/25)
@@ -119,7 +78,7 @@ This tap was created by [DomT4](https://github.com/DomT4) in April 2015 to
 address a personal desire for a background updater, before being moved to
 the Homebrew organisation in April 2021 to become an official part of the
 project after gaining somewhat widespread usage, something I'm both surprised
-by but also very appreciative of people finding a small tool I wrote so
+by, but also very appreciative of people finding a small tool I wrote so
 useful & contributing their own ideas and time towards.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ default) until explicitly told to stop, utilizing `launchd`.
 are optional flags.
 
 Notifications are enabled by default on macOS Big Sur using a new,
-code signed, universal AppleScript applet. On older versions of macOS, if you
-have `terminal-notifier` installed you can also request desktop notifications
+code-signed, universal AppleScript applet. On older versions of macOS, if you
+have `terminal-notifier` installed, you can also request desktop notifications
 when this command runs.
 
 ![A comic highlighting humanity's habit of skipping important updates](https://imgs.xkcd.com/comics/update.png)
@@ -25,11 +25,11 @@ Now run `brew autoupdate start [interval] [options]` to enable autoupdate.
 
 `brew  autoupdate start 43200 --upgrade --cleanup --immediate --sudo`
 
-This will upgrade all your casks and formulae every 12h and on every system boot. <br>
-If a sudo password is required for an upgrade, a GUI to enter you password will be displayed. <br>
+This will upgrade all your casks and formulae every 12 hours and on every system boot. <br>
+If a sudo password is required for an upgrade, a GUI to enter your password will be displayed. <br>
 Also, it will clean up every old version and left-over files.
 
-Casks which have built-in auto updates enabled by default, will not be upgraded.
+Casks that have built-in auto-updates enabled by default will not be upgraded.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An easy, convenient way to automatically update Homebrew.
 
 This script will run `brew update` in the background once every 24 hours (by
-default) until explicitly told to stop, utilizing `launchd`.
+default) until explicitly told to stop, utilising `launchd`.
 
 `brew upgrade` and `brew cleanup` can also be handled automatically, but
 are optional flags.


### PR DESCRIPTION
Follow-up for PR: https://github.com/Homebrew/homebrew-autoupdate/pull/114

* Removed embedded `--help` command output and inserted a link to the auto updated documentation: [Homebrew Documentation autoupdate subcommand](https://docs.brew.sh/Manpage#autoupdate-subcommand-interval-options)
* Added an example and recommended `start` command.
* Fixed some small spelling mistakes

