### PR TITLE
Add missing space to `--sudo` switch description

### DIFF
--- a/cmd/autoupdate.rb
+++ b/cmd/autoupdate.rb
@@ -54,7 +54,7 @@ module Homebrew
                           "instead of waiting for one interval (24 hours by default) to pass first. " \
                           "Must be passed with `start`."
       switch "--sudo",
-             description: "If a Cask requires sudo, autoupdate will open a GUI to ask for the password." \
+             description: "If a Cask requires sudo, autoupdate will open a GUI to ask for the password. " \
                           "Requires https://formulae.brew.sh/formula/pinentry-mac to be installed."
 
       named_args SUBCOMMANDS


### PR DESCRIPTION
Adds a missing space to the `--sudo` switch description text. This is blocking manpage updates in Homebrew/brew. See https://github.com/Homebrew/brew/pull/16208
