### PR TITLE
sudo_gui_script_contents: add timeout, remove unnecessaries

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -97,9 +97,8 @@ module Autoupdate
       set_env << "\nexport SUDO_ASKPASS='#{Autoupdate::Core.location/"brew_autoupdate_sudo_gui"}'"
       sudo_gui_script_contents = <<~EOS
         #!/bin/sh
-        export PATH='#{env_path}'
-        PW="$(printf "%s\n" "SETOK OK" "SETCANCEL Cancel" "SETDESC homebrew-autoupdate needs your admin password to complete the upgrade" "SETPROMPT Enter Password:" "SETTITLE homebrew-autoupdate Password Request" "GETPIN" | pinentry-mac --no-global-grab --timeout 60 | awk '/^D / {print substr($0, index($0, $2))}')"
-        echo "$PW"
+        PATH='#{HOMEBREW_PREFIX}/bin'
+        printf "%s\n" "SETOK OK" "SETCANCEL Cancel" "SETDESC homebrew-autoupdate needs your admin password to complete the upgrade" "SETPROMPT Enter Password:" "SETTITLE homebrew-autoupdate Password Request" "GETPIN" | pinentry-mac --no-global-grab --timeout 60 | /usr/bin/awk '/^D / {print substr($0, index($0, $2))}'
       EOS
     elsif env_sudo
       set_env << "\nexport SUDO_ASKPASS=#{env_sudo}"

--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -98,7 +98,7 @@ module Autoupdate
       sudo_gui_script_contents = <<~EOS
         #!/bin/sh
         export PATH='#{env_path}'
-        PW="$(printf "%s\n" "SETOK OK" "SETCANCEL Cancel" "SETDESC homebrew-autoupdate needs your admin password to complete the upgrade" "SETPROMPT Enter Password:" "SETTITLE homebrew-autoupdate Password Request" "GETPIN" | pinentry-mac --no-global-grab | awk '/^D / {print substr($0, index($0, $2))}')"
+        PW="$(printf "%s\n" "SETOK OK" "SETCANCEL Cancel" "SETDESC homebrew-autoupdate needs your admin password to complete the upgrade" "SETPROMPT Enter Password:" "SETTITLE homebrew-autoupdate Password Request" "GETPIN" | pinentry-mac --no-global-grab --timeout 60 | awk '/^D / {print substr($0, index($0, $2))}')"
         echo "$PW"
       EOS
     elsif env_sudo


### PR DESCRIPTION
### First commit

  - Adds a timeout to `pinentry-mac`. This way, if Homebrew Autoupdate attempts an upgrade with `--sudo` when the user is not available to enter the admin password, the upgrade of that cask can fail and any remaining upgrades can proceed.

### Second commit
  - Eliminates the need to store the admin password in a variable and then print that var to stdout. `sudo --askpass` expects the helper program to output to stdout. pinentry already prints to stdout. That's processed with awk and also printed to stdout already. Addresses my [comment](https://github.com/Homebrew/homebrew-autoupdate/issues/40#issuecomment-1806958098) in issue #40.
  - While there, limit the scope of `PATH`. We already require the formula pinentry-mac, which is linked to `HOMEBREW_PREFIX/bin`. So, set that as PATH and use a full path for `/usr/bin/awk`. That way, we are (more) sure what awk is going to do to the password, too. (An alternative to setting PATH altogether would be calling pinentry like `/usr/bin/env -P"$HOMEBREW_PREFIX/bin" pinentry-mac`.)
  - Just set PATH. There is no need to export it. 