### PR TITLE
upgrade: disable confirmation prompts

### DIFF
--- a/lib/autoupdate/start.rb
+++ b/lib/autoupdate/start.rb
@@ -44,7 +44,7 @@ module Autoupdate
           LEAVES=$(#{Autoupdate::Core.brew} leaves)
           if [ -n "$LEAVES" ]; then
             echo "Upgrading leaves packages only..."
-            #{Autoupdate::Core.brew} upgrade --formula -v $(echo "$LEAVES") || {
+            #{Autoupdate::Core.brew} upgrade --no-ask --formula -v $(echo "$LEAVES") || {
               echo "Warning: Some leaves packages failed to upgrade."
               # Return 0 to ensure the autoupdate process continues
               exit 0
@@ -68,9 +68,9 @@ module Autoupdate
       elsif args.only
         greedy = args.greedy? ? " --greedy" : ""
         package_list = args.only.join(" ")
-        auto_args << " && #{Autoupdate::Core.brew} upgrade -v#{greedy} #{package_list}"
+        auto_args << " && #{Autoupdate::Core.brew} upgrade --no-ask -v#{greedy} #{package_list}"
       else
-        auto_args << " && #{Autoupdate::Core.brew} upgrade --formula -v"
+        auto_args << " && #{Autoupdate::Core.brew} upgrade --no-ask --formula -v"
       end
 
       if !args.only && (HOMEBREW_PREFIX/"Caskroom").exist?
@@ -84,7 +84,7 @@ module Autoupdate
         end
 
         greedy = args.greedy? ? " --greedy" : ""
-        auto_args << " && #{Autoupdate::Core.brew} upgrade --cask -v#{greedy}"
+        auto_args << " && #{Autoupdate::Core.brew} upgrade --no-ask --cask -v#{greedy}"
       end
 
     end

--- a/lib/autoupdate/status.rb
+++ b/lib/autoupdate/status.rb
@@ -65,14 +65,15 @@ module Autoupdate
     plist = Plist.parse_xml(Autoupdate::Core.plist, marshal: false) || {}
     interval = plist["StartInterval"]
     script = updater_script
+    status_script = script.gsub(" upgrade --no-ask", " upgrade")
     details = []
 
     details << "Schedule: every #{Autoupdate::Interval.describe(interval.to_i)} (#{interval} seconds)" if interval
     details << "Run at login: #{plist["RunAtLoad"] ? "yes" : "no"}"
-    details << "Upgrade: #{upgrade_summary(script)}"
+    details << "Upgrade: #{upgrade_summary(status_script)}"
     details << "Cleanup: #{script.include?("#{Autoupdate::Core.brew} cleanup") ? "yes" : "no"}"
     details << "AC power only: #{script.include?("/usr/bin/pmset -g ps") ? "yes" : "no"}"
-    details << "Greedy cask upgrades: yes" if script.include?("upgrade --cask -v --greedy")
+    details << "Greedy cask upgrades: yes" if status_script.include?("upgrade --cask -v --greedy")
     details << "GUI sudo prompt: yes" if script.include?("brew_autoupdate_sudo_gui")
     notification_mode = case script[%r{notifier/notify\.sh "\$status" "\$run_log" (\w+)}, 1]
     when "always" then "yes"

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -109,6 +109,16 @@ class CommandTest < Minitest::Test
     refute_includes stdout, "Last Changed"
   end
 
+  def test_generated_upgrade_commands_disable_confirmation
+    source = File.read(File.join(ROOT, "lib/autoupdate/start.rb"))
+    upgrade_lines = source.lines.grep(/Autoupdate::Core\.brew\} upgrade /)
+
+    assert_equal 4, upgrade_lines.length
+    upgrade_lines.each do |line|
+      assert_includes line, "upgrade --no-ask"
+    end
+  end
+
   private
 
   def brew_autoupdate(*arguments)


### PR DESCRIPTION
Homebrew now defaults brew upgrade to ask mode. Explicitly pass --no-ask for every unattended upgrade path.

Upstream: https://github.com/Homebrew/brew/pull/22601